### PR TITLE
Fix OTEL Collector creation

### DIFF
--- a/yamls/otel-collector-instance.yaml
+++ b/yamls/otel-collector-instance.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   mode: deployment
   observability:
-    enableMetrics: true
+    metrics:
+      enableMetrics: true
   config: |
     receivers:
       otlp:


### PR DESCRIPTION
```sh 
Error from server (BadRequest): error when creating "otel-collector-instance.yaml": OpenTelemetryCollector in version "v1alpha1" cannot be handled as a OpenTelemetryCollector: strict decoding error: unknown field "spec.observability.enableMetrics"
```